### PR TITLE
Check windows EOLs on linux and vice versa.

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -157,6 +157,10 @@ const char* latestFeatures[] = {
 #   define WORD unsigned short
 #endif
 
+#if defined(FOR_WINDOWS) && defined(FOR_LINUX)
+#error Only one target system is allowed
+#endif
+
 #ifndef LLONG_MIN
 #define LLONG_MIN   (-9223372036854775807LL - 1)
 #endif
@@ -3005,7 +3009,7 @@ bool InStream::eoln()
     {
         bool returnCr = false;
 
-#ifdef ON_WINDOWS
+#if (defined(ON_WINDOWS) && !defined(FOR_LINUX)) || defined(FOR_WINDOWS)
         if (c != CR)
         {
             reader->unreadChar(c);


### PR DESCRIPTION
In validation mode all newlines should be native for the running OS (\n on Linux and \r\n on Win), but sometimes it is required to validate tests with non native newlines.
