### PR TITLE
Add Cygwin compatibility

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -144,7 +144,7 @@ const char* latestFeatures[] = {
 #include <stdarg.h>
 #include <fcntl.h>
 
-#if ( _WIN32 || __WIN32__ || _WIN64 || __WIN64__ )
+#if ( _WIN32 || __WIN32__ || _WIN64 || __WIN64__ || __CYGWIN__ )
 #   if !defined(_MSC_VER) || _MSC_VER>1400
 #       include <windows.h>
 #   else


### PR DESCRIPTION
Currently Cygwin gcc doesn't provide any of windows flags (e.g. `__WIN32__`, etc.).
This means, that `testlib.h` will not explicitly include `io.h` header.
Thus, the compilation will abort because it can't find any declaration of `_setmode` (and `setmode` neither).
So there is a point to add `__CYGWIN__` flag check to bring testlib to compile without setting additional macros explicitly.
See also https://cygwin.com/ml/cygwin/2005-08/msg00541.html for learning about `Cygwin` define specs.
