### PR TITLE
Fix compilation on GCC < 4.5

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -3422,11 +3422,14 @@ void registerGen(int argc, char* argv[])
     registerGen(argc, argv, 0);
 }
 #else
-#ifdef __GNUC__
+#if defined(__GNUC__) && (GNUC > 4 || (GNUC == 4 && (GNUC_MINOR > 4)))
     __attribute__ ((deprecated("Use registerGen(argc, argv, 0) or registerGen(argc, argv, 1)."
             " The third parameter stands for the random generator version."
             " If you are trying to compile old generator use macro -DUSE_RND_AS_BEFORE_087 or registerGen(argc, argv, 0)."
             " Version 1 has been released on Spring, 2013. Use it to write new generators.")))
+#endif
+#if defined(__GNUC__) && (GNUC <= 4 || (GNUC == 4 && (GNUC_MINOR <= 4)))
+    __attribute__ ((deprecated))
 #endif
 #ifdef _MSC_VER
     __declspec(deprecated("Use registerGen(argc, argv, 0) or registerGen(argc, argv, 1)."


### PR DESCRIPTION
`__attribute__((deprecated))` did not accept error message until GCC 4.5

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
