### PR TITLE
Fixed readStringTo() to be consistent with eoln().

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -3177,9 +3177,27 @@ void InStream::readStringTo(std::string& result)
 
     for (;;)
     {
-        cur = reader->curChar();
+        cur = reader->nextChar();
 
-        if (isEoln(cur))
+        if (cur == CR)
+        {
+            cur == reader->nextChar();
+
+            if (cur == LF)
+            {
+                reader->unreadChar(LF);
+                reader->unreadChar(CR);
+                break;
+            }
+            else
+            {
+                reader->unreadChar(cur);
+                cur = CR;
+            }
+                
+        }
+
+        if (cur == LF)
             break;
 
         if (cur == EOFC)


### PR DESCRIPTION
readStringTo() stop reading when it reaches CR, LF, or the end of the file.
eoln() reads the patterns CRLF or LF.  This means that it's possible to call
readStringTo() on the string "\r" and not advance the stream pointer at all
without trigger eof.

This means checkers like fcmp/lcmp can loop infinitely if given malformed
expected outputs.  As a simpler example, the below code will loop forever on
the file "\r".

while (!ans.eof())
  string s = ans.readString();
