### PR TITLE
Speed up vtos

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -2215,7 +2215,7 @@ static std::string vtos(const T& t)
 {
     std::string s;
     static std::stringstream ss;
-	ss.str(std::string());
+    ss.str(std::string());
 
     ss << t;
     ss >> s;

--- a/testlib.h
+++ b/testlib.h
@@ -2214,7 +2214,9 @@ template <typename T>
 static std::string vtos(const T& t)
 {
     std::string s;
-    std::stringstream ss;
+    static std::stringstream ss;
+	ss.str(std::string());
+
     ss << t;
     ss >> s;
     return s;


### PR DESCRIPTION
`vtos` function can be very slow because of `std::stringstream` allocation and initialization. For example in validator, that reads 10^6 integers using something like `inf.readInt(1, MAXVAL, "a[" + vtos(i) + "]")` spends about 60%-80% of runtime inside `vtos` function.

Profiling of such validator without patch (74.76% of runtime inside `vtos`)
![before2](https://user-images.githubusercontent.com/1870930/39082299-ae2a4216-4559-11e8-9af0-ad288fa87655.png)

Profiling of such validator with patch (14.66% of runtime inside `vtos`)
![after2](https://user-images.githubusercontent.com/1870930/39082306-c89ae894-4559-11e8-9dc0-fe13d899f194.png)

In practice is gives about 50%-60% performance increasing in such validators and checkers. 

