### PR TITLE
Cover entire code with _TESTLIB_H_ macro

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -4488,8 +4488,6 @@ NORETURN void expectedButFound<long double>(TResult result, long double expected
     __testlib_expectedButFound(result, double(expected), double(found), prepend.c_str());
 }
 
-#endif
-
 #if __cplusplus > 199711L || defined(_MSC_VER)
 template <typename T>
 struct is_iterable
@@ -4679,3 +4677,5 @@ void println(const A& a, const B& b, const C& c, const D& d, const E& e, const F
     std::cout << std::endl;
 }
 #endif
+
+#endif // _TESTLIB_H_


### PR DESCRIPTION
New stuff like `println()` wasn't inside the include guard, so _testlib_ couldn't be included twice. This patch fixes it.