### PR TITLE
Fix include guard

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -4488,8 +4488,6 @@ NORETURN void expectedButFound<long double>(TResult result, long double expected
     __testlib_expectedButFound(result, double(expected), double(found), prepend.c_str());
 }
 
-#endif
-
 #if __cplusplus > 199711L || defined(_MSC_VER)
 template <typename T>
 struct is_iterable
@@ -4678,4 +4676,6 @@ void println(const A& a, const B& b, const C& c, const D& d, const E& e, const F
     __testlib_print_one(g);
     std::cout << std::endl;
 }
+#endif
+
 #endif


### PR DESCRIPTION
Some relatively fresh stuff like "is_iterable", "println", etc are placed outside of the include guard, which leads to the following errors when trying to include testlib.h two times in your program:

```
In file included from interactor.cpp:8:
/usr/include/testlib.h:4495:8: error: redefinition of 'is_iterable'
struct is_iterable
       ^
/usr/include/testlib.h:4495:8: note: previous definition is here
struct is_iterable
       ^
In file included from interactor.cpp:8:
/usr/include/testlib.h:4507:8: error: redefinition of '__testlib_enable_if'
struct __testlib_enable_if {};
       ^
/usr/include/testlib.h:4507:8: note: previous definition is here
struct __testlib_enable_if {};
       ^
...
```