### PR TITLE
fixing include guard

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -4488,8 +4488,6 @@ NORETURN void expectedButFound<long double>(TResult result, long double expected
     __testlib_expectedButFound(result, double(expected), double(found), prepend.c_str());
 }
 
-#endif
-
 #if __cplusplus > 199711L || defined(_MSC_VER)
 template <typename T>
 struct is_iterable
@@ -4678,4 +4676,5 @@ void println(const A& a, const B& b, const C& c, const D& d, const E& e, const F
     __testlib_print_one(g);
     std::cout << std::endl;
 }
+#endif
 #endif


### PR DESCRIPTION
Include guard isn't working. This disallows usage of precompiled headers and isn't any good whatsoever.

**How to reproduce:**

Compile the file:

```
#include "testlib.h"
#include "testlib.h"

int main(int argc, char * argv[])
{
    return 0;
}
```
```
root@instance-1:~$ clang++ check.cpp
In file included from check.cpp:2:
./testlib.h:4495:8: error: redefinition of 'is_iterable'
struct is_iterable
       ^
./testlib.h:4495:8: note: previous definition is here
struct is_iterable
       ^
```
Get redefinition errors.

**Possible workarounds:**
1. `#pragma once` instead of old-school include guards.
2. Fix `#endif` in code, this pr serves as an example. Attached file compiles with such patch.