### PR TITLE
Infinity recursion when write to result file fails

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -2535,8 +2535,10 @@ NORETURN void InStream::quit(TResult result, const char* msg)
     if (resultName != "")
     {
         resultFile = std::fopen(resultName.c_str(), "w");
-        if (resultFile == NULL)
+        if (resultFile == NULL) {
+            resultName = "";
             quit(_fail, "Can not write to the result file");
+        }
         if (appesMode)
         {
             std::fprintf(resultFile, "<?xml version=\"1.0\" encoding=\"windows-1251\"?>");
@@ -2559,8 +2561,10 @@ NORETURN void InStream::quit(TResult result, const char* msg)
         }
         else
              std::fprintf(resultFile, "%s", message.c_str());
-        if (NULL == resultFile || fclose(resultFile) != 0)
+        if (NULL == resultFile || fclose(resultFile) != 0) {
+            resultName = "";
             quit(_fail, "Can not write to the result file");
+        }
     }
 
     quitscr(LightGray, message.c_str());


### PR DESCRIPTION
If checker has no permissions to write to result file it will fall into infinity recursion. It happens because `InStream::quit()` calls itself on error.

### How to reproduce
#### Setup directory like following:
```
answer         : 444 (-r--r--r--) 
checker        : 755 (-rwxr-xr-x) 
input          : 644 (-rw-r--r--) 
output         : 644 (-rw-r--r--) 
result         : 644 (-rw-r--r--) 
```
Note, that answer file has no write permission bit
#### Run checker
```
$ ./checker input output result answer
Segmentation fault (core dumped)
```

### Possible workaround
Clear `resultName` if write to result file fails. So that error will be written to stderr in the call `quit(_fail, "Can not write to the result file");`