### PR TITLE
fix bug: negative character set negates the metacharacter "^" in pattern 

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -1265,6 +1265,7 @@ static std::vector<char> __pattern_scanCharSet(const std::string &s, size_t &pos
     if (__pattern_isCommandChar(s, pos, '[')) {
         pos++;
         bool negative = __pattern_isCommandChar(s, pos, '^');
+        if (negative) pos++;
 
         char prev = 0;
 


### PR DESCRIPTION
When scanning a character set in pattern and found the first character `^`, the `pos` counter should increment; otherwise, the character `^` itself would be negated.