### PR TITLE
fix a bug that a non-std file cannot be reset

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -2798,7 +2798,7 @@ void InStream::reset(std::FILE *file) {
     if (opened)
         close();
 
-    if (!stdfile)
+    if (!stdfile && file == NULL)
         if (NULL == (file = std::fopen(name.c_str(), "rb"))) {
             if (mode == _output)
                 quits(_pe, std::string("Output file not found: \"") + name + "\"");


### PR DESCRIPTION
An non-std file, i.e. a normal file in filesystem, cannot be `reset` or `init` correctly. Because a non-std argument `file` passed into function `void reset(std::FILE *file = NULL)` is always reassigned at line [L2802](https://github.com/namasikanam/testlib/blob/34f535041b6dd42f17829ea8538460c866a58e45/testlib.h#L2802), where the nullness of `file` should be checked before to prevent reassigning.