### PR TITLE
Revert part of commit 8b3719c

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -3186,6 +3186,7 @@ static inline double stringToDouble(InStream &in, const char *buffer) {
         in.quit(_pe, ("Expected double, but \"" + __testlib_part(buffer) + "\" found").c_str());
 
     char *suffix = new char[length + 1];
+    std::memset(suffix, 0, length + 1);
     int scanned = std::sscanf(buffer, "%lf%s", &retval, suffix);
     bool empty = strlen(suffix) == 0;
     delete[] suffix;
@@ -3262,6 +3263,7 @@ static inline double stringToStrictDouble(InStream &in, const char *buffer,
         in.quit(_pe, ("Expected strict double, but \"" + __testlib_part(buffer) + "\" found").c_str());
 
     char *suffix = new char[length + 1];
+    std::memset(suffix, 0, length + 1);
     int scanned = std::sscanf(buffer, "%lf%s", &retval, suffix);
     bool empty = strlen(suffix) == 0;
     delete[] suffix;


### PR DESCRIPTION
Don't know why that commit removed these lines since it will cause UB when `suffix` is empty.