### PR TITLE
chore: not run tests when docs changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: CI
-on: [push, pull_request]
+
+on: 
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'LICENSE'
+      - 'read.me'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'LICENSE'
+      - 'read.me'
+      - 'README.md'
+
 env:
   TEST_REF_FORBID_GEN_REFS: true
 


### PR DESCRIPTION
It looks like CI now also runs when the document changes.

The [`paths-ignore`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) configuration allows PR/commits that only contain docs changes to not run tests.
