### PR TITLE
Remove code to set binary mode on non-Windows systems

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -473,15 +473,6 @@ static void __testlib_set_binary(std::FILE *file) {
 #   else
         setmode(fileno(file), O_BINARY);
 #   endif
-#else
-    if (file == stdin) {
-        if (!freopen(NULL, "rb", file))
-            __testlib_fail("Unable to freopen stdin");
-    }
-    if (file == stdout || file == stderr) {
-        if (!freopen(NULL, "wb", file))
-            __testlib_fail("Unable to freopen stdout/stderr");
-    }
 #endif
     }
 }


### PR DESCRIPTION
There're only difference between "text mode" and "binary mode" on Windows. On Linux and modern UNIX systems there're [no such concept](https://stackoverflow.com/a/2267017).

I removed that pieces of code since it is useless and causes a crash when running on our Linux sandbox-based judge system (in detail, when `stdin` is passed from a privileged user but current process's privilege is dropped).