### PR TITLE
fix: don't skip BOM on standard streams, fix #160

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -3136,7 +3136,6 @@ void InStream::init(std::FILE *f, TMode mode) {
         name = "stderr", stdfile = true;
 
     reset(f);
-    skipBom();
 }
 
 void InStream::skipBom() {


### PR DESCRIPTION
Standard streams does not need to skip BOM, otherwise it will cause infinite waiting (blocking) in interactions.
