### PR TITLE
Fix typos

### DIFF
--- a/checkers/nyesno.cpp
+++ b/checkers/nyesno.cpp
@@ -7,7 +7,7 @@ const string YES = "YES";
 const string NO = "NO";
 
 int main(int argc, char *argv[]) {
-    setName("%s", ("multiple " + YES + "/" + NO + " (case insensetive)").c_str());
+    setName("%s", ("multiple " + YES + "/" + NO + " (case insensitive)").c_str());
     registerTestlibCmd(argc, argv);
 
     int index = 0, yesCount = 0, noCount = 0;

--- a/testlib.h
+++ b/testlib.h
@@ -9,7 +9,7 @@
  * sample generator sources for clarification.
  *
  * Please read the documentation for class "random_t" and use "rnd" instance in
- * generators. Probably, these sample calls will be usefull for you:
+ * generators. Probably, these sample calls will be useful for you:
  *              rnd.next(); rnd.next(100); rnd.next(1, 2);
  *              rnd.next(3.14); rnd.next("[a-z]{1,100}").
  *
@@ -96,7 +96,7 @@ const char *latestFeatures[] = {
         "Introduced space-separated read functions: readWords/readTokens, multilines read functions: readStrings/readLines",
         "Introduced space-separated read functions: readInts/readIntegers/readLongs/readUnsignedLongs/readDoubles/readReals/readStrictDoubles/readStrictReals",
         "Introduced split/tokenize functions to separate string by given char",
-        "Introduced InStream::readUnsignedLong and InStream::readLong with unsigned long long paramerters",
+        "Introduced InStream::readUnsignedLong and InStream::readLong with unsigned long long parameters",
         "Supported --testOverviewLogFileName for validator: bounds hits + features",
         "Fixed UB (sequence points) in random_t",
         "POINTS_EXIT_CODE returned back to 7 (instead of 0)",
@@ -684,7 +684,7 @@ private:
 };
 
 /*
- * Use random_t instances to generate random values. It is preffered
+ * Use random_t instances to generate random values. It is preferred
  * way to use randoms instead of rand() function or self-written
  * randoms.
  *
@@ -2021,7 +2021,7 @@ struct InStream {
      */
     std::string readWord();
 
-    /* The same as "readWord()", it is preffered to use "readToken()". */
+    /* The same as "readWord()", it is preferred to use "readToken()". */
     std::string readToken();
 
     /* The same as "readWord()", but ensures that token matches to given pattern. */
@@ -2270,7 +2270,7 @@ struct InStream {
     NORETURN void quits(TResult result, std::string msg);
 
     /*
-     * Checks condition and aborts a program if codition is false.
+     * Checks condition and aborts a program if condition is false.
      * Returns _wa for ouf and _fail on any other streams.
      */
 #ifdef __GNUC__
@@ -4819,7 +4819,7 @@ std::string join(const _Collection &collection) {
 
 /**
  * Splits string s by character separator returning exactly k+1 items,
- * where k is the number of separator occurences.
+ * where k is the number of separator occurrences.
  */
 std::vector<std::string> split(const std::string &s, char separator) {
     std::vector<std::string> result;
@@ -4836,7 +4836,7 @@ std::vector<std::string> split(const std::string &s, char separator) {
 
 /**
  * Splits string s by character separators returning exactly k+1 items,
- * where k is the number of separator occurences.
+ * where k is the number of separator occurrences.
  */
 std::vector<std::string> split(const std::string &s, const std::string &separators) {
     if (separators.empty())
@@ -5469,7 +5469,7 @@ bool has_opt(const std::string &key) {
     return __testlib_opts.count(key) != 0;
 }
 
-/* About the followings part for opt with 2 and 3 arguments.
+/* About the following part for opt with 2 and 3 arguments.
  * 
  * To parse the argv/opts correctly for a give type (integer, floating point or
  * string), some meta programming must be done to determine the type of
@@ -5869,7 +5869,7 @@ struct TestlibScorerGuard {
 } __testlib_scorer_guard;
 
 void registerScorer(int argc, char *argv[], std::function<double(std::vector<TestResult>)> scorer) {
-    /* Supress unused. */
+    /* Suppress unused. */
     (void)(argc), (void)(argv);
 
     __testlib_ensuresPreconditions();

--- a/tests/lib/testlib.h
+++ b/tests/lib/testlib.h
@@ -9,7 +9,7 @@
  * sample generator sources for clarification.
  *
  * Please read the documentation for class "random_t" and use "rnd" instance in
- * generators. Probably, these sample calls will be usefull for you:
+ * generators. Probably, these sample calls will be useful for you:
  *              rnd.next(); rnd.next(100); rnd.next(1, 2); 
  *              rnd.next(3.14); rnd.next("[a-z]{1,100}").
  *
@@ -86,7 +86,7 @@ const char *latestFeatures[] = {
         "Introduced space-separated read functions: readWords/readTokens, multilines read functions: readStrings/readLines",
         "Introduced space-separated read functions: readInts/readIntegers/readLongs/readUnsignedLongs/readDoubles/readReals/readStrictDoubles/readStrictReals",
         "Introduced split/tokenize functions to separate string by given char",
-        "Introduced InStream::readUnsignedLong and InStream::readLong with unsigned long long paramerters",
+        "Introduced InStream::readUnsignedLong and InStream::readLong with unsigned long long parameters",
         "Supported --testOverviewLogFileName for validator: bounds hits + features",
         "Fixed UB (sequence points) in random_t",
         "POINTS_EXIT_CODE returned back to 7 (instead of 0)",
@@ -527,7 +527,7 @@ private:
 };
 
 /* 
- * Use random_t instances to generate random values. It is preffered
+ * Use random_t instances to generate random values. It is preferred
  * way to use randoms instead of rand() function or self-written 
  * randoms.
  *
@@ -1725,7 +1725,7 @@ struct InStream {
      */
     std::string readWord();
 
-    /* The same as "readWord()", it is preffered to use "readToken()". */
+    /* The same as "readWord()", it is preferred to use "readToken()". */
     std::string readToken();
 
     /* The same as "readWord()", but ensures that token matches to given pattern. */
@@ -1974,7 +1974,7 @@ struct InStream {
     NORETURN void quits(TResult result, std::string msg);
 
     /* 
-     * Checks condition and aborts a program if codition is false.
+     * Checks condition and aborts a program if condition is false.
      * Returns _wa for ouf and _fail on any other streams.
      */
 #ifdef __GNUC__
@@ -4186,7 +4186,7 @@ std::string join(const _Collection &collection) {
 
 /**
  * Splits string s by character separator returning exactly k+1 items,
- * where k is the number of separator occurences.
+ * where k is the number of separator occurrences.
  */
 std::vector<std::string> split(const std::string &s, char separator) {
     std::vector<std::string> result;
@@ -4203,7 +4203,7 @@ std::vector<std::string> split(const std::string &s, char separator) {
 
 /**
  * Splits string s by character separators returning exactly k+1 items,
- * where k is the number of separator occurences.
+ * where k is the number of separator occurrences.
  */
 std::vector<std::string> split(const std::string &s, const std::string &separators) {
     if (separators.empty())


### PR DESCRIPTION
Found typos with:
```
pip install codespell
/home/d/.local/bin/codespell -L ans
```