### PR TITLE
Use utf-8 as checker appes mode report encoding

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -2965,7 +2965,7 @@ NORETURN void InStream::quit(TResult result, const char *msg) {
             quit(_fail, "Can not write to the result file");
         }
         if (appesMode) {
-            std::fprintf(resultFile, "<?xml version=\"1.0\" encoding=\"windows-1251\"?>");
+            std::fprintf(resultFile, "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
             if (isPartial)
                 std::fprintf(resultFile, "<result outcome = \"%s\" pctype = \"%d\">",
                              outcomes[(int) _partially].c_str(), pctype);


### PR DESCRIPTION
`encoding=windows-1251` tells the XML parser to parse the entire XML as windows-1251 encoding. Since this encoding is ASCII compatible, this works fine in most cases. However, some "smart" parsers will parse the XML according to the windows-1251 encoding and cause errors when the message contains characters that are not in the windows-1251 range (such as Chinese characters).

Since modern editors will save code in utf-8 encoding by default, the resulting report information should also be utf-8 encoded.