### PR TITLE
Fix test case message in multitest checkers with partial scores

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -3072,7 +3072,7 @@ NORETURN void InStream::quit(TResult result, const char *msg) {
     message = trim(message);
 
     if (__testlib_hasTestCase) {
-        if (result != _ok)
+        if (result != _ok && result != _points)
             message = __testlib_appendMessage(message, "test case " + vtos(__testlib_testCase));
         else {
             if (__testlib_testCase == 1)


### PR DESCRIPTION
Usually when we have multitest problems and support partial scores, checkers look like that:

```
int points = 0;
for (int i = 1; i <= t; i++) {
  setTestCase(i);
  // check test case i
  points += testPoints;
}
quitp(points);
```

Now testlib prints message `points 12345 (test case 100)` which differs from `quitf(_ok)`: `ok (100 test cases)`. I think similar behavior should be implemented in both cases.