### PR TITLE
Fix potentially unexpected behaviour due to null pointer

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -4913,7 +4913,7 @@ void registerTestlib(int argc, ...) {
 
     va_list ap;
     va_start(ap, argc);
-    argv[0] = NULL;
+    argv[0] = (char*) "checker.exe";
     for (int i = 0; i < argc; i++) {
         argv[i + 1] = va_arg(ap, char*);
     }


### PR DESCRIPTION
Inside the function ``registerTestlib(int argc, ...)``, currently argv[0] is assigned to a null pointer. As a result, the function ``registerTestlibCmd`` is latter invoked with parameter argv[0] equals NULL.

However, inside ``registerTestlibCmd``, there is a line ``std::vector<std::string> args(1, argv[0]). If argv[0] is NULL, this may cause unexpected behaviour. 

It turns out that the exact value of argv[0] is never used, but we should assign it to some default value, instead of a null pointer. 